### PR TITLE
Wesmos D1 Mini WiFi Connection Code

### DIFF
--- a/Wifi_module_Sketch.ino
+++ b/Wifi_module_Sketch.ino
@@ -1,0 +1,33 @@
+#include <ESP8266WiFi.h>
+
+const char* ssid = "Unspecified";
+const char* wifiPassword= "Unspecified";
+
+void setup() 
+{
+  Serial.begin(115200);
+  
+  Serial.print("Wifi connecting to ");
+  Serial.println(ssid);
+  
+  WiFi.begin(ssid,wifiPassword);
+
+  Serial.println();
+  Serial.print("Connecting");
+  while( WiFi.status() != WL_CONNECTED)
+  {
+    delay(500);
+    Serial.print(".");
+  }
+
+  Serial.println("Wifi Connected!!");
+  Serial.println("NodeMCU IP Adress:");
+  Serial.println(WiFi.localIP());
+  
+}
+
+void loop() 
+{
+
+
+}


### PR DESCRIPTION
[Wesmos D1 Mini WiFi Connection Code] 
Theoretically the code only allows the Wesmos the abilitiy to connect a WiFi network. 
The WiFi network is currently unspecified.